### PR TITLE
Add mapViewModifier + Improve ShapeDataBuilder

### DIFF
--- a/Sources/MapLibreSwiftDSL/Data Sources.swift
+++ b/Sources/MapLibreSwiftDSL/Data Sources.swift
@@ -46,9 +46,33 @@ public struct ShapeSource: Source {
 
 @resultBuilder
 public enum ShapeDataBuilder {
-    public static func buildBlock(_ components: MLNShape...) -> ShapeData {
-        let features = components.compactMap({ $0 as? MLNShape & MLNFeature })
-
+    // Handle a single MLNShape element
+    public static func buildExpression(_ expression: MLNShape) -> [MLNShape] {
+        return [expression]
+    }
+    
+    public static func buildExpression(_ expression: [MLNShape]) -> [MLNShape] {
+        return expression
+    }
+    
+    // Combine elements into an array
+    public static func buildBlock(_ components: [MLNShape]...) -> [MLNShape] {
+        return components.flatMap { $0 }
+    }
+    
+    // Handle an array of MLNShape (if you want to directly pass arrays)
+    public static func buildArray(_ components: [MLNShape]) -> [MLNShape] {
+        return components
+    }
+    
+    // Handle for in of MLNShape
+    public static func buildArray(_ components: [[MLNShape]]) -> [MLNShape] {
+        return components.flatMap { $0 }
+    }
+    
+    // Convert the collected MLNShape array to ShapeData
+    public static func buildFinalResult(_ components: [MLNShape]) -> ShapeData {
+        let features = components.compactMap { $0 as? MLNShape & MLNFeature }
         if features.count == components.count {
             return .features(features)
         } else {

--- a/Sources/MapLibreSwiftUI/Examples/Layers.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Layers.swift
@@ -58,19 +58,6 @@ struct Layer_Previews: PreviewProvider {
         }
             .ignoresSafeArea(.all)
             .previewDisplayName("Rotated Symbols (Dynamic)")
-        
-        MapView(styleURL: demoTilesURL) {
-            // Demonstrates how to use the unsafeMapModifier to set MLNMapView properties that have not been exposed as modifiers yet.
-            SymbolStyleLayer(identifier: "simple-symbols", source: pointSource)
-                .iconImage(constant: UIImage(systemName: "mappin")!)
-        }
-        .unsafeMapViewModifier({ mapView in
-            // Not all properties have modifiers yet. Until they do, you can use this 'escape hatch' to the underlying MLNMapView. Be careful: if you modify properties that the DSL controls already, they may be overridden. This modifier is a "hack", not a final function.
-            mapView.logoView.isHidden = false
-            mapView.compassViewPosition = .topLeft
-        })
-        .ignoresSafeArea(.all)
-        .previewDisplayName("Unsafe MapView Modifier")
 
         // FIXME: This appears to be broken upstream; waiting for a new release
 //        MapView(styleURL: demoTilesURL) {

--- a/Sources/MapLibreSwiftUI/Examples/Layers.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Layers.swift
@@ -58,6 +58,19 @@ struct Layer_Previews: PreviewProvider {
         }
             .ignoresSafeArea(.all)
             .previewDisplayName("Rotated Symbols (Dynamic)")
+        
+        MapView(styleURL: demoTilesURL) {
+            // Demonstrates how to use the unsafeMapModifier to set MLNMapView properties that have not been exposed as modifiers yet.
+            SymbolStyleLayer(identifier: "simple-symbols", source: pointSource)
+                .iconImage(constant: UIImage(systemName: "mappin")!)
+        }
+        .unsafeMapViewModifier({ mapView in
+            // Not all properties have modifiers yet. Until they do, you can use this 'escape hatch' to the underlying MLNMapView. Be careful: if you modify properties that the DSL controls already, they may be overridden. This modifier is a "hack", not a final function.
+            mapView.logoView.isHidden = false
+            mapView.compassViewPosition = .topLeft
+        })
+        .ignoresSafeArea(.all)
+        .previewDisplayName("Unsafe MapView Modifier")
 
         // FIXME: This appears to be broken upstream; waiting for a new release
 //        MapView(styleURL: demoTilesURL) {

--- a/Sources/MapLibreSwiftUI/Examples/Other.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Other.swift
@@ -1,0 +1,40 @@
+import CoreLocation
+import MapLibre
+import MapLibreSwiftDSL
+import SwiftUI
+
+struct Other_Previews: PreviewProvider {
+    static var previews: some View {
+        let demoTilesURL = URL(string: "https://demotiles.maplibre.org/style.json")!
+        
+        // A collection of points with various
+        // attributes
+        let pointSource = ShapeSource(identifier: "points") {
+            // Uses the DSL to quickly construct point features inline
+            MLNPointFeature(coordinate: CLLocationCoordinate2D(latitude: 51.47778, longitude: -0.00139))
+            
+            MLNPointFeature(coordinate: CLLocationCoordinate2D(latitude: 0, longitude: 0)) { feature in
+                feature.attributes["icon"] = "missing"
+                feature.attributes["heading"] = 45
+            }
+            
+            MLNPointFeature(coordinate: CLLocationCoordinate2D(latitude: 39.02001, longitude: 1.482148)) { feature in
+                feature.attributes["icon"] = "club"
+                feature.attributes["heading"] = 145
+            }
+        }
+
+        MapView(styleURL: demoTilesURL) {
+            // Demonstrates how to use the unsafeMapModifier to set MLNMapView properties that have not been exposed as modifiers yet.
+            SymbolStyleLayer(identifier: "simple-symbols", source: pointSource)
+                .iconImage(constant: UIImage(systemName: "mappin")!)
+        }
+        .unsafeMapViewModifier({ mapView in
+            // Not all properties have modifiers yet. Until they do, you can use this 'escape hatch' to the underlying MLNMapView. Be careful: if you modify properties that the DSL controls already, they may be overridden. This modifier is a "hack", not a final function.
+            mapView.logoView.isHidden = false
+            mapView.compassViewPosition = .topLeft
+        })
+        .ignoresSafeArea(.all)
+        .previewDisplayName("Unsafe MapView Modifier")
+    }
+}

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -43,6 +43,8 @@ public struct MapView: UIViewRepresentable {
     /// Be careful not to use this to modify properties that are
     /// already ported to the DSL, like the camera for example, as your
     /// modifications here may break updates that occur with modifiers.
+    /// In particular, this modifier is potentially dangerous as it runs on
+    /// EVERY call to `updateUIView`.
     ///
     /// - Parameter modifier: A closure that provides you with an MLNMapView so you can set properties.
     /// - Returns: A MapView with the modifications applied.

--- a/Tests/MapLibreSwiftDSLTests/ShapeSourceTests.swift
+++ b/Tests/MapLibreSwiftDSLTests/ShapeSourceTests.swift
@@ -35,4 +35,24 @@ final class ShapeSourceTests: XCTestCase {
             XCTFail("Expected a feature source")
         }
     }
+    
+    func testForInAndCombinationFeatureBuilder() throws {
+        // ShapeSource now accepts 'for in' building, arrays, and combinations of them
+        let shapeSource = ShapeSource(identifier: "foo") {
+            for coordinates in samplePedestrianWaypoints {
+                MLNPointFeature(coordinate: coordinates)
+            }
+            MLNPointFeature(coordinate: CLLocationCoordinate2D(latitude: 48.2082, longitude: 16.3719))
+        }
+        
+        XCTAssertEqual(shapeSource.identifier, "foo")
+        
+        switch shapeSource.data {
+        case .features(let features):
+            XCTAssertEqual(features.count, 48)
+        default:
+            XCTFail("Expected a feature source")
+        }
+    }
+    
 }


### PR DESCRIPTION
Currently with the lack of view modifiers, it is difficult to set up the mapView the way one may need it. For example, I see no way of setting `showUserLocation`, or changing the position of the compass. So I've created a `mapViewModifier` which allows you to set up the mapView with any of its existing properties, kind of like Introspect does for SwiftUI Views.

I do guess that this project does want to add specific modifiers for all properties at some time - `.compassPosition(.topLeft)` would be more SwiftUI than setting it up via this solution. But until all these modifiers exist this helper modifier would make this spm way more usable.

For more info see the in-code documentation.