### PR TITLE
CircleStyleLayer + SymbolStyleLayer.iconColor

### DIFF
--- a/Sources/MapLibreSwiftDSL/Style Layers/Circle.swift
+++ b/Sources/MapLibreSwiftDSL/Style Layers/Circle.swift
@@ -1,0 +1,80 @@
+import Foundation
+import InternalUtils
+import MapLibre
+import MapLibreSwiftMacros
+
+@MLNStyleProperty<Double>("circleRadius", supportsInterpolation: true)
+@MLNStyleProperty<UIColor>("circleColor", supportsInterpolation: false)
+@MLNStyleProperty<Double>("circleStrokeWidth", supportsInterpolation: true)
+@MLNStyleProperty<UIColor>("circleStrokeColor", supportsInterpolation: true)
+public struct CircleStyleLayer: SourceBoundStyleLayerDefinition {
+    public let identifier: String
+    public var insertionPosition: LayerInsertionPosition = .aboveOthers
+    public var isVisible: Bool = true
+    public var maximumZoomLevel: Float? = nil
+    public var minimumZoomLevel: Float? = nil
+    
+    public var source: StyleLayerSource
+    
+    public init(identifier: String, source: Source) {
+        self.identifier = identifier
+        self.source = .source(source)
+    }
+    
+    public init(identifier: String, source: MLNSource) {
+        self.identifier = identifier
+        self.source = .mglSource(source)
+    }
+    
+    public func makeStyleLayer(style: MLNStyle) -> StyleLayer {
+        let styleSource = addSource(to: style)
+        
+        // Register the images with the map style
+        return CircleStyleLayerInternal(definition: self, mglSource: styleSource)
+    }
+    
+    // MARK: - Modifiers
+    
+}
+
+private struct CircleStyleLayerInternal: StyleLayer {
+    private var definition: CircleStyleLayer
+    private let mglSource: MLNSource
+    
+    public var identifier: String { definition.identifier }
+    public var insertionPosition: LayerInsertionPosition {
+        get { definition.insertionPosition }
+        set { definition.insertionPosition = newValue }
+    }
+    public var isVisible: Bool {
+        get { definition.isVisible }
+        set { definition.isVisible = newValue }
+        
+    }
+    public var maximumZoomLevel: Float? {
+        get { definition.maximumZoomLevel }
+        set { definition.maximumZoomLevel = newValue }
+    }
+    public var minimumZoomLevel: Float? {
+        get { definition.minimumZoomLevel }
+        set { definition.minimumZoomLevel = newValue }
+    }
+    
+    init(definition: CircleStyleLayer, mglSource: MLNSource) {
+        self.definition = definition
+        self.mglSource = mglSource
+    }
+    
+    public func makeMLNStyleLayer() -> MLNStyleLayer {
+        let result = MLNCircleStyleLayer(identifier: identifier, source: mglSource)
+        
+        result.circleRadius = definition.circleRadius
+        
+        result.circleStrokeColor = definition.circleStrokeColor
+        result.circleStrokeWidth = definition.circleStrokeWidth
+        
+        result.circleColor = definition.circleColor
+        
+        return result
+    }
+}

--- a/Sources/MapLibreSwiftDSL/Style Layers/Circle.swift
+++ b/Sources/MapLibreSwiftDSL/Style Layers/Circle.swift
@@ -3,10 +3,10 @@ import InternalUtils
 import MapLibre
 import MapLibreSwiftMacros
 
-@MLNStyleProperty<Double>("circleRadius", supportsInterpolation: true)
-@MLNStyleProperty<UIColor>("circleColor", supportsInterpolation: false)
-@MLNStyleProperty<Double>("circleStrokeWidth", supportsInterpolation: true)
-@MLNStyleProperty<UIColor>("circleStrokeColor", supportsInterpolation: true)
+@MLNStyleProperty<Double>("radius", supportsInterpolation: true)
+@MLNStyleProperty<UIColor>("color", supportsInterpolation: false)
+@MLNStyleProperty<Double>("strokeWidth", supportsInterpolation: true)
+@MLNStyleProperty<UIColor>("strokeColor", supportsInterpolation: false)
 public struct CircleStyleLayer: SourceBoundStyleLayerDefinition {
     public let identifier: String
     public var insertionPosition: LayerInsertionPosition = .aboveOthers
@@ -29,7 +29,6 @@ public struct CircleStyleLayer: SourceBoundStyleLayerDefinition {
     public func makeStyleLayer(style: MLNStyle) -> StyleLayer {
         let styleSource = addSource(to: style)
         
-        // Register the images with the map style
         return CircleStyleLayerInternal(definition: self, mglSource: styleSource)
     }
     
@@ -68,12 +67,12 @@ private struct CircleStyleLayerInternal: StyleLayer {
     public func makeMLNStyleLayer() -> MLNStyleLayer {
         let result = MLNCircleStyleLayer(identifier: identifier, source: mglSource)
         
-        result.circleRadius = definition.circleRadius
+        result.circleRadius = definition.radius
+        result.circleColor = definition.color
         
-        result.circleStrokeColor = definition.circleStrokeColor
-        result.circleStrokeWidth = definition.circleStrokeWidth
+        result.circleStrokeWidth = definition.strokeWidth
+        result.circleStrokeColor = definition.strokeColor
         
-        result.circleColor = definition.circleColor
         
         return result
     }

--- a/Sources/MapLibreSwiftDSL/Style Layers/Symbol.swift
+++ b/Sources/MapLibreSwiftDSL/Style Layers/Symbol.swift
@@ -4,6 +4,8 @@ import MapLibre
 import MapLibreSwiftMacros
 
 @MLNStyleProperty<Double>("iconRotation", supportsInterpolation: true)
+@MLNStyleProperty<UIColor>("iconColor", supportsInterpolation: true)
+
 public struct SymbolStyleLayer: SourceBoundStyleLayerDefinition {
     public let identifier: String
     public var insertionPosition: LayerInsertionPosition = .aboveOthers
@@ -99,6 +101,7 @@ private struct SymbolStyleLayerInternal: StyleLayer {
 
         result.iconImageName = definition.iconImageName
         result.iconRotation = definition.iconRotation
+        result.iconColor = definition.iconColor
 
         return result
     }

--- a/Sources/MapLibreSwiftUI/Examples/Layers.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Layers.swift
@@ -62,10 +62,10 @@ struct Layer_Previews: PreviewProvider {
         MapView(styleURL: demoTilesURL) {
             // Simple symbol layer demonstration with an icon
             CircleStyleLayer(identifier: "simple-circles", source: pointSource)
-                .circleRadius(constant: 16)
-                .circleColor(constant: .systemRed)
-                .circleStrokeWidth(constant: 2)
-                .circleStrokeColor(constant: .white)
+                .radius(constant: 16)
+                .color(constant: .systemRed)
+                .strokeWidth(constant: 2)
+                .strokeColor(constant: .white)
                 
             SymbolStyleLayer(identifier: "simple-symbols", source: pointSource)
                 .iconImage(constant: UIImage(systemName: "mappin")!.withRenderingMode(.alwaysTemplate))

--- a/Sources/MapLibreSwiftUI/Examples/Layers.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Layers.swift
@@ -58,6 +58,20 @@ struct Layer_Previews: PreviewProvider {
         }
             .ignoresSafeArea(.all)
             .previewDisplayName("Rotated Symbols (Dynamic)")
+        
+        MapView(styleURL: demoTilesURL) {
+            // Simple symbol layer demonstration with an icon
+            CircleStyleLayer(identifier: "simple-circles", source: pointSource)
+                .circleRadius(constant: 16)
+                .circleColor(constant: .systemRed)
+                .circleStrokeWidth(constant: 2)
+                .circleStrokeColor(constant: .white)
+                .
+            SymbolStyleLayer(identifier: "simple-symbols", source: pointSource)
+                .iconImage(constant: UIImage(systemName: "mappin")!)
+        }
+        .ignoresSafeArea(.all)
+        .previewDisplayName("Circles with Symbols")
 
         // FIXME: This appears to be broken upstream; waiting for a new release
 //        MapView(styleURL: demoTilesURL) {

--- a/Sources/MapLibreSwiftUI/Examples/Layers.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Layers.swift
@@ -66,9 +66,10 @@ struct Layer_Previews: PreviewProvider {
                 .circleColor(constant: .systemRed)
                 .circleStrokeWidth(constant: 2)
                 .circleStrokeColor(constant: .white)
-                .
+                
             SymbolStyleLayer(identifier: "simple-symbols", source: pointSource)
-                .iconImage(constant: UIImage(systemName: "mappin")!)
+                .iconImage(constant: UIImage(systemName: "mappin")!.withRenderingMode(.alwaysTemplate))
+                .iconColor(constant: .white)
         }
         .ignoresSafeArea(.all)
         .previewDisplayName("Circles with Symbols")


### PR DESCRIPTION
- Made a copy of the SymbolStyleLayer code and then modified it to be a CircleStyleLayer. 
- Added an example for usage.
- Added .iconColor for SymbolStyleLayer

Here's a screenshot of a circle layer under a symbol layer.

![Simulator Screenshot - iPhone 15 Pro - 2024-01-27 at 21 33 54](https://github.com/stadiamaps/maplibre-swiftui-dsl-playground/assets/645674/e5138ac7-81b2-4dc5-81ea-aa5a26c21483)

