### PR TITLE
Add support for camera bounding box

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "3df876f8f2c6c591b0f66a29b3e216020afc885c",
-        "version" : "6.0.0"
+        "revision" : "818e1d6b83e4cbe8482eca3e6e57d3f560926157",
+        "version" : "6.1.1"
       }
     },
     {

--- a/Sources/MapLibreSwiftUI/Extensions/MapLibre/MLNMapViewCameraUpdating.swift
+++ b/Sources/MapLibreSwiftUI/Extensions/MapLibre/MLNMapViewCameraUpdating.swift
@@ -13,6 +13,7 @@ protocol MLNMapViewCameraUpdating: AnyObject {
                    direction: CLLocationDirection,
                    animated: Bool)
     func setZoomLevel(_ zoomLevel: Double, animated: Bool)
+	func setVisibleCoordinateBounds(_ bounds: MLNCoordinateBounds, edgePadding: UIEdgeInsets, animated: Bool, completionHandler: (() -> Void)?)
 }
 
 extension MLNMapView: MLNMapViewCameraUpdating {

--- a/Sources/MapLibreSwiftUI/Extensions/MapLibre/MLNMapViewCameraUpdating.swift
+++ b/Sources/MapLibreSwiftUI/Extensions/MapLibre/MLNMapViewCameraUpdating.swift
@@ -13,7 +13,12 @@ protocol MLNMapViewCameraUpdating: AnyObject {
                    direction: CLLocationDirection,
                    animated: Bool)
     func setZoomLevel(_ zoomLevel: Double, animated: Bool)
-	func setVisibleCoordinateBounds(_ bounds: MLNCoordinateBounds, edgePadding: UIEdgeInsets, animated: Bool, completionHandler: (() -> Void)?)
+    func setVisibleCoordinateBounds(
+        _ bounds: MLNCoordinateBounds,
+        edgePadding: UIEdgeInsets,
+        animated: Bool,
+        completionHandler: (() -> Void)?
+    )
 }
 
 extension MLNMapView: MLNMapViewCameraUpdating {

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -61,7 +61,11 @@ public class MapViewCoordinator: NSObject {
         case .trackingUserLocationWithCourse:
             mapView.userTrackingMode = .followWithCourse
             mapView.setZoomLevel(camera.zoom, animated: false)
-        case .rect, .showcase:
+		case let .rect(northeast, southwest):
+			let bounds = MLNCoordinateBounds(sw: southwest, ne: northeast)
+			let padding: UIEdgeInsets = .init(top: 20, left: 20, bottom: 20, right: 20)
+			(mapView as? MLNMapView)?.setVisibleCoordinateBounds(bounds, edgePadding: padding, animated: animated, completionHandler: nil)
+        case .showcase:
             // TODO: Need a method these/or to finalize a goal here.
             break
         }

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -61,10 +61,11 @@ public class MapViewCoordinator: NSObject {
         case .trackingUserLocationWithCourse:
             mapView.userTrackingMode = .followWithCourse
             mapView.setZoomLevel(camera.zoom, animated: false)
-		case let .rect(northeast, southwest):
-			let bounds = MLNCoordinateBounds(sw: southwest, ne: northeast)
-			let padding: UIEdgeInsets = .init(top: 20, left: 20, bottom: 20, right: 20)
-			(mapView as? MLNMapView)?.setVisibleCoordinateBounds(bounds, edgePadding: padding, animated: animated, completionHandler: nil)
+		case let .rect(boundingBox, padding):
+			mapView.setVisibleCoordinateBounds(boundingBox,
+											   edgePadding: padding,
+											   animated: animated,
+											   completionHandler: nil)
         case .showcase:
             // TODO: Need a method these/or to finalize a goal here.
             break

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -63,11 +63,11 @@ public class MapViewCoordinator: NSObject {
         case .trackingUserLocationWithCourse:
             mapView.userTrackingMode = .followWithCourse
             mapView.setZoomLevel(camera.zoom, animated: false)
-		case let .rect(boundingBox, padding):
-			mapView.setVisibleCoordinateBounds(boundingBox,
-											   edgePadding: padding,
-											   animated: animated,
-											   completionHandler: nil)
+        case let .rect(boundingBox, padding):
+            mapView.setVisibleCoordinateBounds(boundingBox,
+                                               edgePadding: padding,
+                                               animated: animated,
+                                               completionHandler: nil)
         case .showcase:
             // TODO: Need a method these/or to finalize a goal here.
             break

--- a/Sources/MapLibreSwiftUI/Models/MapCamera/CameraState.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapCamera/CameraState.swift
@@ -25,7 +25,10 @@ public enum CameraState: Hashable {
     case trackingUserLocationWithCourse
 
     /// Centered on a bounding box/rectangle.
-	case rect(boundingBox: MLNCoordinateBounds, edgePadding: UIEdgeInsets = .init(top: 20, left: 20, bottom: 20, right: 20))
+    case rect(
+        boundingBox: MLNCoordinateBounds,
+        edgePadding: UIEdgeInsets = .init(top: 20, left: 20, bottom: 20, right: 20)
+    )
 
     /// Showcasing GeoJSON, Polygons, etc.
     case showcase(shapeCollection: MLNShapeCollection)
@@ -42,32 +45,30 @@ extension CameraState: CustomDebugStringConvertible {
             "CameraState.trackingUserLocationWithHeading"
         case .trackingUserLocationWithCourse:
             "CameraState.trackingUserLocationWithCourse"
-		case .rect(boundingBox: let boundingBox, _):
-			"CameraState.rect(northeast: \(boundingBox.ne), southwest: \(boundingBox.sw))"
-        case .showcase(shapeCollection: let shapeCollection):
+        case let .rect(boundingBox: boundingBox, _):
+            "CameraState.rect(northeast: \(boundingBox.ne), southwest: \(boundingBox.sw))"
+        case let .showcase(shapeCollection: shapeCollection):
             "CameraState.showcase(shapeCollection: \(shapeCollection))"
         }
     }
 }
 
 extension MLNCoordinateBounds: Equatable, Hashable {
-	
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(self.ne)
-		hasher.combine(self.sw)
-	}
-	
-	public static func == (lhs: MLNCoordinateBounds, rhs: MLNCoordinateBounds) -> Bool {
-		return lhs.ne == rhs.ne && lhs.sw == rhs.sw
-	}
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(ne)
+        hasher.combine(sw)
+    }
+
+    public static func == (lhs: MLNCoordinateBounds, rhs: MLNCoordinateBounds) -> Bool {
+        lhs.ne == rhs.ne && lhs.sw == rhs.sw
+    }
 }
 
 extension UIEdgeInsets: Hashable {
-	
-	public func hash(into hasher: inout Hasher) {
-		hasher.combine(self.left)
-		hasher.combine(self.right)
-		hasher.combine(self.top)
-		hasher.combine(self.bottom)
-	}
+    public func hash(into hasher: inout Hasher) {
+        hasher.combine(left)
+        hasher.combine(right)
+        hasher.combine(top)
+        hasher.combine(bottom)
+    }
 }

--- a/Sources/MapLibreSwiftUI/Models/MapCamera/CameraState.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapCamera/CameraState.swift
@@ -26,7 +26,7 @@ public enum CameraState: Hashable {
     case trackingUserLocationWithCourse
     
     /// Centered on a bounding box/rectangle.
-	case rect(boundingBox: MLNCoordinateBounds, edgePadding: UIEdgeInsets)
+	case rect(boundingBox: MLNCoordinateBounds, edgePadding: UIEdgeInsets = .init(top: 20, left: 20, bottom: 20, right: 20))
     
     /// Showcasing GeoJSON, Polygons, etc.
     case showcase(shapeCollection: MLNShapeCollection)

--- a/Sources/MapLibreSwiftUI/Models/MapCamera/CameraState.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapCamera/CameraState.swift
@@ -26,7 +26,7 @@ public enum CameraState: Hashable {
     case trackingUserLocationWithCourse
     
     /// Centered on a bounding box/rectangle.
-    case rect(northeast: CLLocationCoordinate2D, southwest: CLLocationCoordinate2D) // TODO: make a bounding box?
+	case rect(boundingBox: MLNCoordinateBounds, edgePadding: UIEdgeInsets)
     
     /// Showcasing GeoJSON, Polygons, etc.
     case showcase(shapeCollection: MLNShapeCollection)
@@ -44,10 +44,32 @@ extension CameraState: CustomDebugStringConvertible {
             return "CameraState.trackingUserLocationWithHeading"
         case .trackingUserLocationWithCourse:
             return "CameraState.trackingUserLocationWithCourse"
-        case .rect(northeast: let northeast, southwest: let southwest):
-            return "CameraState.rect(northeast: \(northeast), southwest: \(southwest))"
+		case .rect(boundingBox: let boundingBox, _):
+			return "CameraState.rect(northeast: \(boundingBox.ne), southwest: \(boundingBox.sw))"
         case .showcase(shapeCollection: let shapeCollection):
             return "CameraState.showcase(shapeCollection: \(shapeCollection))"
         }
     }
+}
+
+extension MLNCoordinateBounds: Equatable, Hashable {
+	
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(self.ne)
+		hasher.combine(self.sw)
+	}
+	
+	public static func == (lhs: MLNCoordinateBounds, rhs: MLNCoordinateBounds) -> Bool {
+		return lhs.ne == rhs.ne && lhs.sw == rhs.sw
+	}
+}
+
+extension UIEdgeInsets: Hashable {
+	
+	public func hash(into hasher: inout Hasher) {
+		hasher.combine(self.left)
+		hasher.combine(self.right)
+		hasher.combine(self.top)
+		hasher.combine(self.bottom)
+	}
 }

--- a/Sources/MapLibreSwiftUI/Models/MapCamera/MapViewCamera.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapCamera/MapViewCamera.swift
@@ -117,4 +117,17 @@ public struct MapViewCamera: Hashable {
     }
     
     // TODO: Create init methods for other camera states once supporting materials are understood (e.g. BoundingBox)
+	
+	public static func boundingBox(northeast: CLLocationCoordinate2D,
+								   southwest: CLLocationCoordinate2D, 
+								   zoom: Double,
+								   pitch: CameraPitch = Defaults.pitch,
+								   direction: CLLocationDirection = Defaults.direction,
+								   reason: CameraChangeReason? = nil) -> MapViewCamera {
+		return MapViewCamera(state: .rect(northeast: northeast, southwest: southwest),
+							 zoom: zoom,
+							 pitch: pitch,
+							 direction: direction,
+							 lastReasonForChange: reason)
+	}
 }

--- a/Sources/MapLibreSwiftUI/Models/MapCamera/MapViewCamera.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapCamera/MapViewCamera.swift
@@ -115,19 +115,21 @@ public struct MapViewCamera: Hashable {
                              direction: Defaults.direction,
                              lastReasonForChange: .programmatic)
     }
-    
-    // TODO: Create init methods for other camera states once supporting materials are understood (e.g. BoundingBox)
 	
-	public static func boundingBox(northeast: CLLocationCoordinate2D,
-								   southwest: CLLocationCoordinate2D, 
-								   zoom: Double,
-								   pitch: CameraPitch = Defaults.pitch,
-								   direction: CLLocationDirection = Defaults.direction,
-								   reason: CameraChangeReason? = nil) -> MapViewCamera {
-		return MapViewCamera(state: .rect(northeast: northeast, southwest: southwest),
-							 zoom: zoom,
-							 pitch: pitch,
-							 direction: direction,
-							 lastReasonForChange: reason)
+	/// Positions the camera to show a specific region in the MapView.
+	///
+	/// - Parameters:
+	///   - box: Set the desired bounding box. This is a one time event and the user can manipulate by moving the map.
+	///   - edgePadding: Set the edge insets that should be applied before positioning the map.
+	/// - Returns: The MapViewCamera representing the scenario
+	public static func boundingBox(_ box: MLNCoordinateBounds, edgePadding: UIEdgeInsets = .init(top: 20, left: 20, bottom: 20, right: 20)) -> MapViewCamera {
+		// zoom, pitch & direction are ignored.
+		return MapViewCamera(state: .rect(boundingBox: box, edgePadding: edgePadding),
+							 zoom: 1,
+							 pitch: Defaults.pitch,
+							 direction: Defaults.direction,
+							 lastReasonForChange: .programmatic)
 	}
+	
+	// TODO: Create init methods for other camera states once supporting materials are understood (e.g. BoundingBox)
 }

--- a/Sources/MapLibreSwiftUI/Models/MapCamera/MapViewCamera.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapCamera/MapViewCamera.swift
@@ -117,19 +117,22 @@ public struct MapViewCamera: Hashable {
                       direction: Defaults.direction,
                       lastReasonForChange: .programmatic)
     }
-	
-	/// Positions the camera to show a specific region in the MapView.
-	///
-	/// - Parameters:
-	///   - box: Set the desired bounding box. This is a one time event and the user can manipulate by moving the map.
-	///   - edgePadding: Set the edge insets that should be applied before positioning the map.
-	/// - Returns: The MapViewCamera representing the scenario
-	public static func boundingBox(_ box: MLNCoordinateBounds, edgePadding: UIEdgeInsets = .init(top: 20, left: 20, bottom: 20, right: 20)) -> MapViewCamera {
-		// zoom, pitch & direction are ignored.
-		return MapViewCamera(state: .rect(boundingBox: box, edgePadding: edgePadding),
-							 zoom: 1,
-							 pitch: Defaults.pitch,
-							 direction: Defaults.direction,
-							 lastReasonForChange: .programmatic)
-	}
+
+    /// Positions the camera to show a specific region in the MapView.
+    ///
+    /// - Parameters:
+    ///   - box: Set the desired bounding box. This is a one time event and the user can manipulate by moving the map.
+    ///   - edgePadding: Set the edge insets that should be applied before positioning the map.
+    /// - Returns: The MapViewCamera representing the scenario
+    public static func boundingBox(
+        _ box: MLNCoordinateBounds,
+        edgePadding: UIEdgeInsets = .init(top: 20, left: 20, bottom: 20, right: 20)
+    ) -> MapViewCamera {
+        // zoom, pitch & direction are ignored.
+        MapViewCamera(state: .rect(boundingBox: box, edgePadding: edgePadding),
+                      zoom: 1,
+                      pitch: Defaults.pitch,
+                      direction: Defaults.direction,
+                      lastReasonForChange: .programmatic)
+    }
 }

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/CameraStateTests.swift
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/CameraStateTests.swift
@@ -33,8 +33,8 @@ final class CameraStateTests: XCTestCase {
         let northeast = CLLocationCoordinate2D(latitude: 12.3, longitude: 23.4)
         let southwest = CLLocationCoordinate2D(latitude: 34.5, longitude: 45.6)
         
-        let state: CameraState = .rect(northeast: northeast, southwest: southwest)
-        XCTAssertEqual(state, .rect(northeast: northeast, southwest: southwest))
+		let state: CameraState = .rect(boundingBox: .init(sw: southwest, ne: northeast))
+		XCTAssertEqual(state, .rect(boundingBox: .init(sw: southwest, ne: northeast)))
         XCTAssertEqual(
             String(describing: state),
             "CameraState.rect(northeast: CLLocationCoordinate2D(latitude: 12.3, longitude: 23.4), southwest: CLLocationCoordinate2D(latitude: 34.5, longitude: 45.6))")

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/CameraStateTests.swift
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/CameraStateTests.swift
@@ -34,9 +34,9 @@ final class CameraStateTests: XCTestCase {
     func testRect() {
         let northeast = CLLocationCoordinate2D(latitude: 12.3, longitude: 23.4)
         let southwest = CLLocationCoordinate2D(latitude: 34.5, longitude: 45.6)
-        
-		let state: CameraState = .rect(boundingBox: .init(sw: southwest, ne: northeast))
-		XCTAssertEqual(state, .rect(boundingBox: .init(sw: southwest, ne: northeast)))
+
+        let state: CameraState = .rect(boundingBox: .init(sw: southwest, ne: northeast))
+        XCTAssertEqual(state, .rect(boundingBox: .init(sw: southwest, ne: northeast)))
 
         XCTAssertEqual(
             String(describing: state),

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/MapViewCameraTests.swift
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/MapViewCameraTests.swift
@@ -1,5 +1,6 @@
-import XCTest
 import CoreLocation
+import MapLibre
+import XCTest
 @testable import MapLibreSwiftUI
 
 final class MapViewCameraTests: XCTestCase {
@@ -45,6 +46,18 @@ final class MapViewCameraTests: XCTestCase {
         XCTAssertEqual(camera.pitch, .free)
         XCTAssertEqual(camera.direction, 0)
     }
+	
+	func testBoundingBox() {
+		let southwest = CLLocationCoordinate2D(latitude: 24.6056011, longitude: 46.67369842529297)
+		let northeast = CLLocationCoordinate2D(latitude: 24.6993808, longitude: 46.7709285)
+		let bounds = MLNCoordinateBounds(sw: southwest, ne: northeast)
+		let camera = MapViewCamera.boundingBox(bounds)
+		
+		XCTAssertEqual(camera.state, .rect(boundingBox: bounds, edgePadding: .init(top: 20, left: 20, bottom: 20, right: 20)))
+		XCTAssertEqual(camera.zoom, 1)
+		XCTAssertEqual(camera.pitch, .free)
+		XCTAssertEqual(camera.direction, 0)
+	}
     
     // TODO: Add additional camera tests once behaviors are added (e.g. rect)
     

--- a/Tests/MapLibreSwiftUITests/Models/MapCamera/MapViewCameraTests.swift
+++ b/Tests/MapLibreSwiftUITests/Models/MapCamera/MapViewCameraTests.swift
@@ -45,18 +45,21 @@ final class MapViewCameraTests: XCTestCase {
         XCTAssertEqual(camera.pitch, .free)
         XCTAssertEqual(camera.direction, 0)
     }
-	
-	func testBoundingBox() {
-		let southwest = CLLocationCoordinate2D(latitude: 24.6056011, longitude: 46.67369842529297)
-		let northeast = CLLocationCoordinate2D(latitude: 24.6993808, longitude: 46.7709285)
-		let bounds = MLNCoordinateBounds(sw: southwest, ne: northeast)
-		let camera = MapViewCamera.boundingBox(bounds)
-		
-		XCTAssertEqual(camera.state, .rect(boundingBox: bounds, edgePadding: .init(top: 20, left: 20, bottom: 20, right: 20)))
-		XCTAssertEqual(camera.zoom, 1)
-		XCTAssertEqual(camera.pitch, .free)
-		XCTAssertEqual(camera.direction, 0)
-	}
+
+    func testBoundingBox() {
+        let southwest = CLLocationCoordinate2D(latitude: 24.6056011, longitude: 46.67369842529297)
+        let northeast = CLLocationCoordinate2D(latitude: 24.6993808, longitude: 46.7709285)
+        let bounds = MLNCoordinateBounds(sw: southwest, ne: northeast)
+        let camera = MapViewCamera.boundingBox(bounds)
+
+        XCTAssertEqual(
+            camera.state,
+            .rect(boundingBox: bounds, edgePadding: .init(top: 20, left: 20, bottom: 20, right: 20))
+        )
+        XCTAssertEqual(camera.zoom, 1)
+        XCTAssertEqual(camera.pitch, .free)
+        XCTAssertEqual(camera.direction, 0)
+    }
 
     // TODO: Add additional camera tests once behaviors are added (e.g. rect)
 }


### PR DESCRIPTION
### Description

Allow showing map in a bounding box, therefore extend MapViewCamera.

### Tasks

- [x] extend MapViewCamera with boundingBox init
- [x] extend MLNMapViewCameraUpdating protocol 
- [x] add tests

### Infos for Reviewer

We might need to update MapViewCamera as zoom, pitch & direction are not needed for every camera configuration. We have the option to either make all of them optional, however then we lose swift compile checks, instead I would propose to move these properties to each enum case in CameraState.