### PR TITLE
Setting up DocC

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,5 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [MapLibreSwiftUI]
+      platform: ios

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/maplibre/maplibre-gl-native-distribution.git",
       "state" : {
-        "revision" : "3df876f8f2c6c591b0f66a29b3e216020afc885c",
-        "version" : "6.0.0"
+        "revision" : "818e1d6b83e4cbe8482eca3e6e57d3f560926157",
+        "version" : "6.1.1"
       }
     },
     {

--- a/Sources/MapLibreSwiftUI/Documentation.docc/MapLibreSwiftUI.md
+++ b/Sources/MapLibreSwiftUI/Documentation.docc/MapLibreSwiftUI.md
@@ -1,0 +1,38 @@
+# ``MapLibreSwiftUI``
+
+A SwiftUI framework for Maplibre Native iOS. Provides declarative methods for MapLibre inspired by default SwiftUI functionality.
+
+## Overview
+
+```swift
+struct MyView: View {
+    
+    @State var camera: MapViewCamera = .default()
+
+    var body: some View {
+        MapView(
+            styleURL: URL(string: "https://demotiles.maplibre.org/style.json")!,
+            camera: $camera
+        ) {
+            // Declarative overlay features.
+        }
+        .onTapMapGesture { context in 
+            // Handle tap gesture context
+        }
+    }
+}
+```
+
+## Topics
+
+### MapView
+
+- ``MapView``
+
+### MapViewCamera
+
+- ``MapViewCamera``
+- ``CameraState``
+- ``CameraPitch``
+- ``CameraChangeReason``
+


### PR DESCRIPTION
- Adds basic DocC configuration for MapLibreSwiftUI
- Adds .spi.yml (https://github.com/stadiamaps/maplibre-swiftui-dsl-playground/issues/20)

Closes #20 (maybe)