### PR TITLE
Feature Gestures

### DIFF
--- a/Sources/MapLibreSwiftUI/Examples/Gestures.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Gestures.swift
@@ -1,0 +1,40 @@
+//
+//  File.swift
+//  
+//
+//  Created by patrick on 29.03.24.
+//
+
+import CoreLocation
+import MapLibre
+import MapLibreSwiftDSL
+import SwiftUI
+
+
+#Preview("Tappable Circles") {
+    let tappableID = "simple-circles"
+    return MapView(styleURL: demoTilesURL) {
+        // Simple symbol layer demonstration with an icon
+        CircleStyleLayer(identifier: tappableID, source: pointSource)
+            .radius(16)
+            .color(.systemRed)
+            .strokeWidth(2)
+            .strokeColor(.white)
+        
+        SymbolStyleLayer(identifier: "simple-symbols", source: pointSource)
+            .iconImage(UIImage(systemName: "mappin")!.withRenderingMode(.alwaysTemplate))
+            .iconColor(.white)
+    }
+    .onTapMapGesture(on: [tappableID], onTapChanged: { _, features in
+        print("Tapped on \(features.first)")
+    })
+    .ignoresSafeArea(.all)
+}
+
+#Preview("Tappable Countries") {
+    MapView(styleURL: demoTilesURL)
+    .onTapMapGesture(on: ["countries-fill"], onTapChanged: { _, features in
+        print("Tapped on \(features.first)")
+    })
+    .ignoresSafeArea(.all)
+}

--- a/Sources/MapLibreSwiftUI/Examples/Gestures.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Gestures.swift
@@ -1,15 +1,7 @@
-//
-//  File.swift
-//  
-//
-//  Created by patrick on 29.03.24.
-//
-
 import CoreLocation
 import MapLibre
 import MapLibreSwiftDSL
 import SwiftUI
-
 
 #Preview("Tappable Circles") {
     let tappableID = "simple-circles"
@@ -20,7 +12,7 @@ import SwiftUI
             .color(.systemRed)
             .strokeWidth(2)
             .strokeColor(.white)
-        
+
         SymbolStyleLayer(identifier: "simple-symbols", source: pointSource)
             .iconImage(UIImage(systemName: "mappin")!.withRenderingMode(.alwaysTemplate))
             .iconColor(.white)
@@ -33,8 +25,8 @@ import SwiftUI
 
 #Preview("Tappable Countries") {
     MapView(styleURL: demoTilesURL)
-    .onTapMapGesture(on: ["countries-fill"], onTapChanged: { _, features in
-        print("Tapped on \(features.first)")
-    })
-    .ignoresSafeArea(.all)
+        .onTapMapGesture(on: ["countries-fill"], onTapChanged: { _, features in
+            print("Tapped on \(features.first)")
+        })
+        .ignoresSafeArea(.all)
 }

--- a/Sources/MapLibreSwiftUI/Extensions/MapView/MapViewGestures.swift
+++ b/Sources/MapLibreSwiftUI/Extensions/MapView/MapViewGestures.swift
@@ -53,11 +53,6 @@ extension MapView {
     /// gesture.
     ///   - sender: The UIGestureRecognizer
     @MainActor func processGesture(_ mapView: MLNMapView, _ sender: UIGestureRecognizer) {
-        guard sender.state == .ended else {
-            // We should only process gestures that have ended, else built in gestures like double tapping the map
-            // interfere with ours.
-            return
-        }
         guard let gesture = gestures.first(where: { $0.gestureRecognizer == sender }) else {
             assertionFailure("\(sender) is not a registered UIGestureRecongizer on the MapView")
             return

--- a/Sources/MapLibreSwiftUI/Extensions/MapView/MapViewGestures.swift
+++ b/Sources/MapLibreSwiftUI/Extensions/MapView/MapViewGestures.swift
@@ -18,7 +18,11 @@ extension MapView {
             if numberOfTaps == 1 {
                 // If a user double taps to zoom via the built in gesture, a normal
                 // tap should not be triggered.
-                if let doubleTapRecognizer = mapView.gestureRecognizers?.first(where: { $0 is UITapGestureRecognizer && ($0 as! UITapGestureRecognizer).numberOfTapsRequired == 2 }) {
+                if let doubleTapRecognizer = mapView.gestureRecognizers?
+                    .first(where: {
+                        $0 is UITapGestureRecognizer && ($0 as! UITapGestureRecognizer).numberOfTapsRequired == 2
+                    })
+                {
                     gestureRecognizer.require(toFail: doubleTapRecognizer)
                 }
             }
@@ -49,7 +53,6 @@ extension MapView {
     /// gesture.
     ///   - sender: The UIGestureRecognizer
     @MainActor func processGesture(_ mapView: MLNMapView, _ sender: UIGestureRecognizer) {
-        
         guard sender.state == .ended else {
             // We should only process gestures that have ended, else built in gestures like double tapping the map
             // interfere with ours.
@@ -59,15 +62,14 @@ extension MapView {
             assertionFailure("\(sender) is not a registered UIGestureRecongizer on the MapView")
             return
         }
-        
 
         // Process the gesture into a context response.
         let context = processContextFromGesture(mapView, gesture: gesture, sender: sender)
         // Run the context through the gesture held on the MapView (emitting to the MapView modifier).
         switch gesture.onChange {
-        case .context(let action):
+        case let .context(action):
             action(context)
-        case .feature(let action, let layers):
+        case let .feature(action, layers):
             let point = sender.location(in: sender.view)
             let features = mapView.visibleFeatures(at: point, styleLayerIdentifiers: layers)
             action(context, features)

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -10,6 +10,7 @@ public struct MapView: UIViewRepresentable {
     let userLayers: [StyleLayerDefinition]
 
     var gestures = [MapGesture]()
+    
     var onStyleLoaded: ((MLNStyle) -> Void)?
 
     public var mapViewContentInset: UIEdgeInsets = .zero

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -10,7 +10,7 @@ public struct MapView: UIViewRepresentable {
     let userLayers: [StyleLayerDefinition]
 
     var gestures = [MapGesture]()
-    
+
     var onStyleLoaded: ((MLNStyle) -> Void)?
 
     public var mapViewContentInset: UIEdgeInsets = .zero

--- a/Sources/MapLibreSwiftUI/MapViewModifiers.swift
+++ b/Sources/MapLibreSwiftUI/MapViewModifiers.swift
@@ -64,17 +64,17 @@ public extension MapView {
 
         return newMapView
     }
-    
+
     func onTapMapGesture(count: Int = 1, on layers: Set<String>?,
                          onTapChanged: @escaping (MapGestureContext, [any MLNFeature]) -> Void) -> MapView
     {
         var newMapView = self
-        
+
         // Build the gesture and link it to the map view.
         let gesture = MapGesture(method: .tap(numberOfTaps: count),
                                  onChange: .feature(onTapChanged, layers: layers))
         newMapView.gestures.append(gesture)
-        
+
         return newMapView
     }
 

--- a/Sources/MapLibreSwiftUI/MapViewModifiers.swift
+++ b/Sources/MapLibreSwiftUI/MapViewModifiers.swift
@@ -50,7 +50,8 @@ public extension MapView {
     ///
     /// - Parameters:
     ///   - count: The number of taps required to run the gesture.
-    ///   - onTapChanged: Emits the context whenever the gesture changes (e.g. began, ended, etc).
+    ///   - onTapChanged: Emits the context whenever the gesture changes (e.g. began, ended, etc), that also contains
+    /// information like the latitude and longitude of the tap.
     /// - Returns: The modified map view.
     func onTapMapGesture(count: Int = 1,
                          onTapChanged: @escaping (MapGestureContext) -> Void) -> MapView
@@ -65,6 +66,16 @@ public extension MapView {
         return newMapView
     }
 
+    /// Add an tap gesture handler to the MapView that returns any visible map features that were tapped.
+    ///
+    /// - Parameters:
+    ///   - count: The number of taps required to run the gesture.
+    ///   - on layers: The set of layer ids that you would like to check for visible features that were tapped. If no
+    /// set is provided, all map layers are checked.
+    ///   - onTapChanged: Emits the context whenever the gesture changes (e.g. began, ended, etc), that also contains
+    /// information like the latitude and longitude of the tap. Also emits an array of map features that were tapped.
+    /// Returns an empty array when nothing was tapped on the "on" layer ids that were provided.
+    /// - Returns: The modified map view.
     func onTapMapGesture(count: Int = 1, on layers: Set<String>?,
                          onTapChanged: @escaping (MapGestureContext, [any MLNFeature]) -> Void) -> MapView
     {

--- a/Sources/MapLibreSwiftUI/MapViewModifiers.swift
+++ b/Sources/MapLibreSwiftUI/MapViewModifiers.swift
@@ -59,9 +59,22 @@ public extension MapView {
 
         // Build the gesture and link it to the map view.
         let gesture = MapGesture(method: .tap(numberOfTaps: count),
-                                 onChange: onTapChanged)
+                                 onChange: .context(onTapChanged))
         newMapView.gestures.append(gesture)
 
+        return newMapView
+    }
+    
+    func onTapMapGesture(count: Int = 1, on layers: Set<String>?,
+                         onTapChanged: @escaping (MapGestureContext, [any MLNFeature]) -> Void) -> MapView
+    {
+        var newMapView = self
+        
+        // Build the gesture and link it to the map view.
+        let gesture = MapGesture(method: .tap(numberOfTaps: count),
+                                 onChange: .feature(onTapChanged, layers: layers))
+        newMapView.gestures.append(gesture)
+        
         return newMapView
     }
 
@@ -78,7 +91,7 @@ public extension MapView {
 
         // Build the gesture and link it to the map view.
         let gesture = MapGesture(method: .longPress(minimumDuration: minimumDuration),
-                                 onChange: onPressChanged)
+                                 onChange: .context(onPressChanged))
         newMapView.gestures.append(gesture)
 
         return newMapView

--- a/Sources/MapLibreSwiftUI/Models/Gesture/MapGesture.swift
+++ b/Sources/MapLibreSwiftUI/Models/Gesture/MapGesture.swift
@@ -1,5 +1,5 @@
-import UIKit
 import MapLibre
+import UIKit
 
 public class MapGesture: NSObject {
     public enum Method: Equatable {

--- a/Sources/MapLibreSwiftUI/Models/Gesture/MapGesture.swift
+++ b/Sources/MapLibreSwiftUI/Models/Gesture/MapGesture.swift
@@ -1,4 +1,5 @@
 import UIKit
+import MapLibre
 
 public class MapGesture: NSObject {
     public enum Method: Equatable {
@@ -19,7 +20,7 @@ public class MapGesture: NSObject {
     let method: Method
 
     /// The onChange action that runs when the gesture changes on the map view.
-    let onChange: (MapGestureContext) -> Void
+    let onChange: GestureAction
 
     /// The underlying gesture recognizer
     weak var gestureRecognizer: UIGestureRecognizer?
@@ -29,8 +30,13 @@ public class MapGesture: NSObject {
     /// - Parameters:
     ///   - method: The gesture recognizer method
     ///   - onChange: The action to perform when the gesture is changed
-    init(method: Method, onChange: @escaping (MapGestureContext) -> Void) {
+    init(method: Method, onChange: GestureAction) {
         self.method = method
         self.onChange = onChange
     }
+}
+
+public enum GestureAction {
+    case context((MapGestureContext) -> Void)
+    case feature((MapGestureContext, [any MLNFeature]) -> Void, layers: Set<String>?)
 }

--- a/Tests/MapLibreSwiftUITests/MapView/MapViewGestureTests.swift
+++ b/Tests/MapLibreSwiftUITests/MapView/MapViewGestureTests.swift
@@ -28,9 +28,10 @@ final class MapViewGestureTests: XCTestCase {
     // MARK: Gesture Processing
 
     @MainActor func testTapGesture() {
-        let gesture = MapGesture(method: .tap(numberOfTaps: 2)) { _ in
+        
+        let gesture = MapGesture(method: .tap(numberOfTaps: 2), onChange: .context({ _ in
             // Do nothing
-        }
+        }))
 
         let mockTapGesture = MockUIGestureRecognizing()
 
@@ -53,9 +54,11 @@ final class MapViewGestureTests: XCTestCase {
     }
 
     @MainActor func testLongPressGesture() {
-        let gesture = MapGesture(method: .longPress(minimumDuration: 1)) { _ in
+        
+        let gesture = MapGesture(method: .longPress(minimumDuration: 1), onChange: .context({ _ in
             // Do nothing
-        }
+        }))
+
 
         let mockTapGesture = MockUIGestureRecognizing()
 

--- a/Tests/MapLibreSwiftUITests/MapView/MapViewGestureTests.swift
+++ b/Tests/MapLibreSwiftUITests/MapView/MapViewGestureTests.swift
@@ -28,10 +28,9 @@ final class MapViewGestureTests: XCTestCase {
     // MARK: Gesture Processing
 
     @MainActor func testTapGesture() {
-        
-        let gesture = MapGesture(method: .tap(numberOfTaps: 2), onChange: .context({ _ in
+        let gesture = MapGesture(method: .tap(numberOfTaps: 2), onChange: .context { _ in
             // Do nothing
-        }))
+        })
 
         let mockTapGesture = MockUIGestureRecognizing()
 
@@ -54,11 +53,9 @@ final class MapViewGestureTests: XCTestCase {
     }
 
     @MainActor func testLongPressGesture() {
-        
-        let gesture = MapGesture(method: .longPress(minimumDuration: 1), onChange: .context({ _ in
+        let gesture = MapGesture(method: .longPress(minimumDuration: 1), onChange: .context { _ in
             // Do nothing
-        }))
-
+        })
 
         let mockTapGesture = MockUIGestureRecognizing()
 

--- a/Tests/MapLibreSwiftUITests/Models/Gesture/MapGestureTests.swift
+++ b/Tests/MapLibreSwiftUITests/Models/Gesture/MapGestureTests.swift
@@ -4,7 +4,9 @@ import XCTest
 final class MapGestureTests: XCTestCase {
     func testTapGestureDefaults() {
         let gesture = MapGesture(method: .tap(),
-                                 onChange: { _ in })
+                                 onChange: .context({ _ in
+            
+        }))
 
         XCTAssertEqual(gesture.method, .tap())
         XCTAssertNil(gesture.gestureRecognizer)
@@ -12,7 +14,9 @@ final class MapGestureTests: XCTestCase {
 
     func testTapGesture() {
         let gesture = MapGesture(method: .tap(numberOfTaps: 3),
-                                 onChange: { _ in })
+                                 onChange: .context({ _ in
+            
+        }))
 
         XCTAssertEqual(gesture.method, .tap(numberOfTaps: 3))
         XCTAssertNil(gesture.gestureRecognizer)
@@ -20,7 +24,9 @@ final class MapGestureTests: XCTestCase {
 
     func testLongPressGestureDefaults() {
         let gesture = MapGesture(method: .longPress(),
-                                 onChange: { _ in })
+                                 onChange: .context({ _ in
+            
+        }))
 
         XCTAssertEqual(gesture.method, .longPress())
         XCTAssertNil(gesture.gestureRecognizer)
@@ -28,7 +34,9 @@ final class MapGestureTests: XCTestCase {
 
     func testLongPressGesture() {
         let gesture = MapGesture(method: .longPress(minimumDuration: 3),
-                                 onChange: { _ in })
+                                 onChange: .context({ _ in
+            
+        }))
 
         XCTAssertEqual(gesture.method, .longPress(minimumDuration: 3))
         XCTAssertNil(gesture.gestureRecognizer)

--- a/Tests/MapLibreSwiftUITests/Models/Gesture/MapGestureTests.swift
+++ b/Tests/MapLibreSwiftUITests/Models/Gesture/MapGestureTests.swift
@@ -4,9 +4,9 @@ import XCTest
 final class MapGestureTests: XCTestCase {
     func testTapGestureDefaults() {
         let gesture = MapGesture(method: .tap(),
-                                 onChange: .context({ _ in
-            
-        }))
+                                 onChange: .context { _ in
+
+                                 })
 
         XCTAssertEqual(gesture.method, .tap())
         XCTAssertNil(gesture.gestureRecognizer)
@@ -14,9 +14,9 @@ final class MapGestureTests: XCTestCase {
 
     func testTapGesture() {
         let gesture = MapGesture(method: .tap(numberOfTaps: 3),
-                                 onChange: .context({ _ in
-            
-        }))
+                                 onChange: .context { _ in
+
+                                 })
 
         XCTAssertEqual(gesture.method, .tap(numberOfTaps: 3))
         XCTAssertNil(gesture.gestureRecognizer)
@@ -24,9 +24,9 @@ final class MapGestureTests: XCTestCase {
 
     func testLongPressGestureDefaults() {
         let gesture = MapGesture(method: .longPress(),
-                                 onChange: .context({ _ in
-            
-        }))
+                                 onChange: .context { _ in
+
+                                 })
 
         XCTAssertEqual(gesture.method, .longPress())
         XCTAssertNil(gesture.gestureRecognizer)
@@ -34,9 +34,9 @@ final class MapGestureTests: XCTestCase {
 
     func testLongPressGesture() {
         let gesture = MapGesture(method: .longPress(minimumDuration: 3),
-                                 onChange: .context({ _ in
-            
-        }))
+                                 onChange: .context { _ in
+
+                                 })
 
         XCTAssertEqual(gesture.method, .longPress(minimumDuration: 3))
         XCTAssertNil(gesture.gestureRecognizer)


### PR DESCRIPTION
As we discussed in https://github.com/stadiamaps/maplibre-swiftui-dsl-playground/issues/18 I have added support for tapping map features. I see that you have added gestures already, so I tried to base my addition on your implementation, adding a `GestureAction` enum to support different kinds of closures for the MapView. I know you guys want to have gestures on DSL layer level too and I agree with that, but as said we need to support it on map level for layers that are not added via DSL, but are baked into the loaded style. For example, to make the countries in the demo preview tap-able, one can now do this:

```Swift
#Preview("Tappable Countries") {
    MapView(styleURL: demoTilesURL)
        .onTapMapGesture(on: ["countries-fill"], onTapChanged: { _, features in
            print("Tapped on \(features.first)")
        })
        .ignoresSafeArea(.all)
}
```

So this solution is on MapView level, not on layer level, and can be used for both until we add layer level support later.

I've only done tap now, but adding longPress for this would now be trivial if you are happy with this PR.

This also fixes an issue where an added tap gesture is triggered even though a user double taps the map (which causes a zoom) by requiring that gesture to fail first before our custom gestures can trigger.