### PR TITLE
MapViewPort implementation to listen to raw values of 'camera'

### DIFF
--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -11,6 +11,7 @@ public struct MapView: UIViewRepresentable {
 
     var gestures = [MapGesture]()
     var onStyleLoaded: ((MLNStyle) -> Void)?
+    var onViewPortChanged: ((MapViewPort) -> Void)?
 
     public var mapViewContentInset: UIEdgeInsets = .zero
     public var isLogoViewHidden = false
@@ -42,7 +43,8 @@ public struct MapView: UIViewRepresentable {
     public func makeCoordinator() -> MapViewCoordinator {
         MapViewCoordinator(
             parent: self,
-            onGesture: { processGesture($0, $1) }
+            onGesture: { processGesture($0, $1) },
+            onViewPortChanged: { onViewPortChanged?($0) }
         )
     }
 

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -207,9 +207,9 @@ extension MapViewCoordinator: MLNMapViewDelegate {
         addLayers(to: mglStyle)
         onStyleLoaded?(mglStyle)
     }
-    
+
     // MARK: MapViewCamera
-    
+
     @MainActor private func updateParentCamera(mapView: MLNMapView, reason: MLNCameraChangeReason) {
         // If any of these are a mismatch, we know the camera is no longer following a desired method, so we should
         // detach and revert to a .centered camera. If any one of these is true, the desired camera state still
@@ -227,13 +227,13 @@ extension MapViewCoordinator: MLNMapViewDelegate {
         case .centered, .rect, .showcase:
             false
         }
-        
+
         guard !isProgrammaticallyTracking else {
             // Programmatic tracking is still active, we can ignore camera updates until we unset/fail this boolean
             // check
             return
         }
-        
+
         // Publish the MLNMapView's "raw" camera state to the MapView camera binding.
         // This path only executes when the map view diverges from the parent state, so this is a "matter of fact"
         // state propagation.
@@ -241,15 +241,15 @@ extension MapViewCoordinator: MLNMapViewDelegate {
                                                zoom: mapView.zoomLevel,
                                                // TODO: Pitch doesn't really describe current state
                                                pitch: .freeWithinRange(
-                                                minimum: mapView.minimumPitch,
-                                                maximum: mapView.maximumPitch
+                                                   minimum: mapView.minimumPitch,
+                                                   maximum: mapView.maximumPitch
                                                ),
                                                direction: mapView.direction,
                                                reason: CameraChangeReason(reason))
         snapshotCamera = newCamera
         parent.camera = newCamera
     }
-    
+
     /// The MapView's region has changed with a specific reason.
     public func mapView(_ mapView: MLNMapView, regionDidChangeWith reason: MLNCameraChangeReason, animated _: Bool) {
         // FIXME: CI complains about MainActor.assumeIsolated being unavailable before iOS 17, despite building on iOS 17.2... This is an epic hack to fix it for now. I can only assume this is an issue with Xcode pre-15.3
@@ -257,19 +257,19 @@ extension MapViewCoordinator: MLNMapViewDelegate {
         Task { @MainActor in
             updateViewPort(mapView: mapView)
         }
-        
+
         guard !suppressCameraUpdatePropagation else {
             return
         }
-        
+
         // FIXME: CI complains about MainActor.assumeIsolated being unavailable before iOS 17, despite building on iOS 17.2... This is an epic hack to fix it for now. I can only assume this is an issue with Xcode pre-15.3
         Task { @MainActor in
             updateParentCamera(mapView: mapView, reason: reason)
         }
     }
-    
+
     // MARK: MapViewPort
-    
+
     @MainActor private func updateViewPort(mapView: MLNMapView) {
         // Calculate the Raw "ViewPort"
         let calculatedViewPort = MapViewPort(
@@ -277,7 +277,7 @@ extension MapViewCoordinator: MLNMapViewDelegate {
             zoom: mapView.zoomLevel,
             direction: mapView.direction
         )
-        
+
         onViewPortChanged(calculatedViewPort)
     }
 }

--- a/Sources/MapLibreSwiftUI/MapViewModifiers.swift
+++ b/Sources/MapLibreSwiftUI/MapViewModifiers.swift
@@ -99,7 +99,7 @@ public extension MapView {
 
         return result
     }
-    
+
     func onMapViewPortUpdate(_ onViewPortChanged: @escaping (MapViewPort) -> Void) -> Self {
         var result = self
         result.onViewPortChanged = onViewPortChanged

--- a/Sources/MapLibreSwiftUI/MapViewModifiers.swift
+++ b/Sources/MapLibreSwiftUI/MapViewModifiers.swift
@@ -99,4 +99,10 @@ public extension MapView {
 
         return result
     }
+    
+    func onMapViewPortUpdate(_ onViewPortChanged: @escaping (MapViewPort) -> Void) -> Self {
+        var result = self
+        result.onViewPortChanged = onViewPortChanged
+        return result
+    }
 }

--- a/Sources/MapLibreSwiftUI/Models/MapViewPort.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapViewPort.swift
@@ -1,0 +1,43 @@
+import Foundation
+import CoreLocation
+
+/// A representation of the MapView's current ViewPort.
+///
+/// This includes similar data to the MapViewCamera, but represents the raw
+/// values associated with the MapView. This information could used to prepare
+/// a new MapViewCamera on a scene, to cache the camera state, etc.
+public struct MapViewPort: Hashable, Equatable {
+    
+    /// The current center coordinate of the MapView
+    public let center: CLLocationCoordinate2D
+    
+    /// The current zoom value of the MapView
+    public let zoom: Double
+    
+    /// The current compass direction of the MapView
+    public let direction: CLLocationDirection
+    
+    public init(center: CLLocationCoordinate2D, zoom: Double, direction: CLLocationDirection) {
+        self.center = center
+        self.zoom = zoom
+        self.direction = direction
+    }
+    
+    public static func zero(zoom: Double = 10) -> MapViewPort {
+        return MapViewPort(center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                           zoom: zoom,
+                           direction: 0)
+    }
+}
+
+extension MapViewPort {
+    
+    /// Generate a basic MapViewCamera that represents the MapViewPort
+    ///
+    /// - Returns: The calculated MapViewCamera
+    public func asMapViewCamera() -> MapViewCamera {
+        return .center(center,
+                       zoom: zoom,
+                       direction: direction)
+    }
+}

--- a/Sources/MapLibreSwiftUI/Models/MapViewPort.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapViewPort.swift
@@ -1,5 +1,5 @@
-import Foundation
 import CoreLocation
+import Foundation
 
 /// A representation of the MapView's current ViewPort.
 ///
@@ -7,37 +7,35 @@ import CoreLocation
 /// values associated with the MapView. This information could used to prepare
 /// a new MapViewCamera on a scene, to cache the camera state, etc.
 public struct MapViewPort: Hashable, Equatable {
-    
     /// The current center coordinate of the MapView
     public let center: CLLocationCoordinate2D
-    
+
     /// The current zoom value of the MapView
     public let zoom: Double
-    
+
     /// The current compass direction of the MapView
     public let direction: CLLocationDirection
-    
+
     public init(center: CLLocationCoordinate2D, zoom: Double, direction: CLLocationDirection) {
         self.center = center
         self.zoom = zoom
         self.direction = direction
     }
-    
+
     public static func zero(zoom: Double = 10) -> MapViewPort {
-        return MapViewPort(center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
-                           zoom: zoom,
-                           direction: 0)
+        MapViewPort(center: CLLocationCoordinate2D(latitude: 0, longitude: 0),
+                    zoom: zoom,
+                    direction: 0)
     }
 }
 
-extension MapViewPort {
-    
+public extension MapViewPort {
     /// Generate a basic MapViewCamera that represents the MapViewPort
     ///
     /// - Returns: The calculated MapViewCamera
-    public func asMapViewCamera() -> MapViewCamera {
-        return .center(center,
-                       zoom: zoom,
-                       direction: direction)
+    func asMapViewCamera() -> MapViewCamera {
+        .center(center,
+                zoom: zoom,
+                direction: direction)
     }
 }

--- a/Tests/MapLibreSwiftUITests/MapViewCoordinator/MapViewCoordinatorCameraTests.swift
+++ b/Tests/MapLibreSwiftUITests/MapViewCoordinator/MapViewCoordinatorCameraTests.swift
@@ -13,6 +13,8 @@ final class MapViewCoordinatorCameraTests: XCTestCase {
         mapView = MapView(styleURL: URL(string: "https://maplibre.org")!)
         coordinator = MapView.Coordinator(parent: mapView) { _, _ in
             // No action
+        } onViewPortChanged: { _ in
+            // No action
         }
     }
 


### PR DESCRIPTION
- Adds MapViewPort concept for modifier callback style updates of the MapViewPort (think the actual rawValue of the camera even when the state camera is set to an automatic mode like tracking).