### PR TITLE
Change MapStyle

### DIFF
--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -83,6 +83,13 @@ public struct MapView: UIViewRepresentable {
 
     public func updateUIView(_ mapView: MLNMapView, context: Context) {
         context.coordinator.parent = self
+        
+        switch styleSource {
+        case let .url(styleURL):
+            if styleURL != mapView.styleURL {
+                mapView.styleURL = styleURL
+            }
+        }
 
         applyModifiers(mapView, runUnsafe: true)
 

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -83,7 +83,7 @@ public struct MapView: UIViewRepresentable {
 
     public func updateUIView(_ mapView: MLNMapView, context: Context) {
         context.coordinator.parent = self
-        
+
         switch styleSource {
         case let .url(styleURL):
             if styleURL != mapView.styleURL {

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -84,13 +84,6 @@ public struct MapView: UIViewRepresentable {
     public func updateUIView(_ mapView: MLNMapView, context: Context) {
         context.coordinator.parent = self
 
-        switch styleSource {
-        case let .url(styleURL):
-            if styleURL != mapView.styleURL {
-                mapView.styleURL = styleURL
-            }
-        }
-
         applyModifiers(mapView, runUnsafe: true)
 
         // FIXME: This should be a more selective update

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -11,6 +11,7 @@ public class MapViewCoordinator: NSObject {
     // every update cycle so we can avoid unnecessary updates
     private var snapshotUserLayers: [StyleLayerDefinition] = []
     private var snapshotCamera: MapViewCamera?
+    private var snapshotStyleSource: MapStyleSource?
 
     // Indicates whether we are currently in a push-down camera update cycle.
     // This is necessary in order to ensure we don't keep trying to reset a state value which we were already processing
@@ -102,12 +103,16 @@ public class MapViewCoordinator: NSObject {
     // MARK: - Coordinator API - Styles + Layers
 
     @MainActor func updateStyleSource(_ source: MapStyleSource, mapView: MLNMapView) {
-        switch (source, parent.styleSource) {
+        switch (source, snapshotStyleSource) {
         case let (.url(newURL), .url(oldURL)):
             if newURL != oldURL {
                 mapView.styleURL = newURL
             }
+        case let (.url(newURL), .none):
+            mapView.styleURL = newURL
         }
+
+        snapshotStyleSource = source
     }
 
     @MainActor func updateLayers(mapView: MLNMapView) {


### PR DESCRIPTION
Because we only set the mapStyle during `makeUIView`, a later change to the styleURL parameter does nothing. This PR adds a check to `updateUIView`  to see if the styleURL changed, and if yes, sets the new URL on the mapView, allowing users to change the mapStyle at runtime (for example to change from a vector to a satellite map style).