### PR TITLE
Expand Clusters on Tap

### DIFF
--- a/Sources/MapLibreSwiftUI/Examples/Layers.swift
+++ b/Sources/MapLibreSwiftUI/Examples/Layers.swift
@@ -123,6 +123,13 @@ let clustered = ShapeSource(identifier: "points", options: [.clustered: true, .c
             .iconColor(.white)
             .predicate(NSPredicate(format: "cluster != YES"))
     }
+    .onTapMapGesture(on: ["simple-circles-non-clusters"], onTapChanged: { _, features in
+        print("Tapped on \(features.first)")
+    })
+    .expandClustersOnTapping(clusteredLayers: [ClusterLayer(
+        layerIdentifier: "simple-circles-clusters",
+        sourceIdentifier: "points"
+    )])
     .ignoresSafeArea(.all)
 }
 

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -28,6 +28,8 @@ public struct MapView: UIViewRepresentable {
 
     private var locationManager: MLNLocationManager?
 
+    var clusteredLayers: [ClusterLayer]?
+
     public init(
         styleURL: URL,
         camera: Binding<MapViewCamera> = .constant(.default()),

--- a/Sources/MapLibreSwiftUI/MapViewModifiers.swift
+++ b/Sources/MapLibreSwiftUI/MapViewModifiers.swift
@@ -108,6 +108,18 @@ public extension MapView {
         return newMapView
     }
 
+    /// Add a default implementation for tapping clustered features. When tapped, the map zooms so that the cluster is
+    /// expanded.
+    /// - Parameter clusteredLayers: An array of layers to monitor that can contain clustered features.
+    /// - Returns: The modified MapView
+    func expandClustersOnTapping(clusteredLayers: [ClusterLayer]) -> MapView {
+        var newMapView = self
+
+        newMapView.clusteredLayers = clusteredLayers
+
+        return newMapView
+    }
+
     func mapViewContentInset(_ inset: UIEdgeInsets) -> Self {
         var result = self
 


### PR DESCRIPTION
This PR adds an expandClustersOnTapping viewModifier. When used, if a user taps a cluster feature, the expand function of its source is used to choose a new zoom level.

I chose a slightly different implementation than discussed. Instead of taking a toggle bool, it takes an array of ClusterLayer which describes which layers/sources are the cluster layers. The reason is that the `visibleFeatures` function does not return which layer or source was tapped, so if we do not require users to provide which layers and sources to check, our implementation would instead need to go through all sources and layers of the map until it finds where this tapped cluster feature originated from. By making users provide us with the potential layers/sources, this makes the process more efficient and allows for filtering if required. 