### PR TITLE
Fix camera binding issues

### DIFF
--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -5,7 +5,7 @@ import SwiftUI
 
 public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentable {
     public typealias UIViewControllerType = T
-    var cameraDisabled: Bool = true
+    var cameraDisabled: Bool = false
 
     @Binding var camera: MapViewCamera
 

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -18,7 +18,7 @@ public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentab
     var onStyleLoaded: ((MLNStyle) -> Void)?
     var onViewPortChanged: ((MapViewPort) -> Void)?
 
-    public var mapViewContentInset: UIEdgeInsets = .zero
+    var mapViewContentInset: UIEdgeInsets? = .zero
 
     var unsafeMapViewControllerModifier: ((T) -> Void)?
 
@@ -103,13 +103,16 @@ public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentab
 
         if cameraDisabled == false {
             context.coordinator.updateCamera(mapView: uiViewController.mapView,
-                                             camera: $camera.wrappedValue,
+                                             camera: camera,
                                              animated: isStyleLoaded)
         }
     }
 
     @MainActor private func applyModifiers(_ mapViewController: T, runUnsafe: Bool) {
-        mapViewController.mapView.contentInset = mapViewContentInset
+        if let mapViewContentInset {
+            mapViewController.mapView.automaticallyAdjustsContentInset = false
+            mapViewController.mapView.contentInset = mapViewContentInset
+        }
 
         // Assume all controls are hidden by default (so that an empty list returns a map with no controls)
         mapViewController.mapView.logoView.isHidden = true


### PR DESCRIPTION
This fixes two issues with camera handling introduced in #39.

* The default configuration disables all camera updates. While this may be required for certain edge use cases, this should not be the default.
* The default behavior of `MLNMapView` within a `UIViewController` creates an "edit war" if you are trying to set content insets, which all navigation use cases will need to do. This was pretty hard to foresee, but the docs on the `contentInsets` property do mention the behavior.