### PR TITLE
Adopt Swift 6 concurrency norms

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: Test
 
 on:
   push:
-    branches: [ "*" ]
+    branches: [ main ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,7 +29,7 @@ jobs:
         ]
         destination: [
           # TODO: Add more destinations
-          'platform=iOS Simulator,name=iPhone 15,OS=17.2'
+          'platform=iOS Simulator,name=iPhone 15,OS=17.5'
         ]
 
     steps:
@@ -38,7 +38,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: '15.2'
+        xcode-version: '15.4'
 
     - name: Checkout maplibre-swiftui-dsl-playground
       uses: actions/checkout@v4

--- a/Sources/MapLibreSwiftUI/MLNMapViewController.swift
+++ b/Sources/MapLibreSwiftUI/MLNMapViewController.swift
@@ -3,10 +3,11 @@ import UIKit
 
 public protocol MapViewHostViewController: UIViewController {
     associatedtype MapType: MLNMapView
-    var mapView: MapType { get }
+    @MainActor var mapView: MapType { get }
 }
 
 public final class MLNMapViewController: UIViewController, MapViewHostViewController {
+    @MainActor
     public var mapView: MLNMapView {
         view as! MLNMapView
     }

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -351,7 +351,7 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapV
         // TODO: We could put this in regionIsChangingWith if we calculate significant change/debounce.
         MainActor.assumeIsolated {
             updateViewPort(mapView: mapView, reason: reason)
-            
+
             guard !suppressCameraUpdatePropagation else {
                 return
             }

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -348,18 +348,14 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapV
 
     /// The MapView's region has changed with a specific reason.
     public func mapView(_ mapView: MLNMapView, regionDidChangeWith reason: MLNCameraChangeReason, animated _: Bool) {
-        // FIXME: CI complains about MainActor.assumeIsolated being unavailable before iOS 17, despite building on iOS 17.2... This is an epic hack to fix it for now. I can only assume this is an issue with Xcode pre-15.3
         // TODO: We could put this in regionIsChangingWith if we calculate significant change/debounce.
         MainActor.assumeIsolated {
             updateViewPort(mapView: mapView, reason: reason)
-        }
+            
+            guard !suppressCameraUpdatePropagation else {
+                return
+            }
 
-        guard !suppressCameraUpdatePropagation else {
-            return
-        }
-
-        // FIXME: CI complains about MainActor.assumeIsolated being unavailable before iOS 17, despite building on iOS 17.2... This is an epic hack to fix it for now. I can only assume this is an issue with Xcode pre-15.3
-        MainActor.assumeIsolated {
             updateParentCamera(mapView: mapView, reason: reason)
         }
     }

--- a/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
+++ b/Sources/MapLibreSwiftUI/MapViewCoordinator.swift
@@ -350,7 +350,7 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapV
     public func mapView(_ mapView: MLNMapView, regionDidChangeWith reason: MLNCameraChangeReason, animated _: Bool) {
         // FIXME: CI complains about MainActor.assumeIsolated being unavailable before iOS 17, despite building on iOS 17.2... This is an epic hack to fix it for now. I can only assume this is an issue with Xcode pre-15.3
         // TODO: We could put this in regionIsChangingWith if we calculate significant change/debounce.
-        Task { @MainActor in
+        MainActor.assumeIsolated {
             updateViewPort(mapView: mapView, reason: reason)
         }
 
@@ -359,7 +359,7 @@ public class MapViewCoordinator<T: MapViewHostViewController>: NSObject, MLNMapV
         }
 
         // FIXME: CI complains about MainActor.assumeIsolated being unavailable before iOS 17, despite building on iOS 17.2... This is an epic hack to fix it for now. I can only assume this is an issue with Xcode pre-15.3
-        Task { @MainActor in
+        MainActor.assumeIsolated {
             updateParentCamera(mapView: mapView, reason: reason)
         }
     }


### PR DESCRIPTION
What the title says. This should not result in any functional or "real" changes.