### PR TITLE
expose text font names as a modifier

### DIFF
--- a/Sources/MapLibreSwiftDSL/Style Layers/Symbol.swift
+++ b/Sources/MapLibreSwiftDSL/Style Layers/Symbol.swift
@@ -10,6 +10,7 @@ import MapLibreSwiftMacros
 @MLNStyleProperty<UIColor>("textColor", supportsInterpolation: true)
 @MLNStyleProperty<Double>("textFontSize", supportsInterpolation: true)
 @MLNStyleProperty<String>("text", supportsInterpolation: false)
+@MLNStyleProperty<[String]?>("textFontNames", supportsInterpolation: false)
 // An enum would probably be better?
 @MLNStyleProperty<String>("textAnchor", supportsInterpolation: false)
 @MLNStyleProperty<CGVector>("textOffset", supportsInterpolation: true)
@@ -148,6 +149,7 @@ private struct SymbolStyleLayerInternal: StyleLayer {
         result.maximumTextWidth = definition.maximumTextWidth
         result.textAnchor = definition.textAnchor
         result.textOffset = definition.textOffset
+        result.textFontNames = definition.textFontNames
 
         result.textHaloColor = definition.textHaloColor
         result.textHaloWidth = definition.textHaloWidth


### PR DESCRIPTION
Consumers of SwiftUI dsl are now able to customize the font family for the `text` attribute for `SymbolLayer`. It provides a solution to [this problem](https://github.com/stadiamaps/maplibre-swiftui-dsl-playground/issues/46). According to the [docs](https://maplibre.org/maplibre-native/ios/latest/documentation/maplibre/mlnsymbolstylelayer/textfontnames), the font family can be set to nil to reset to default value, so the exposed type is `[String]?`