### PR TITLE
fix: revert main actor on camera

### DIFF
--- a/Sources/MapLibreSwiftUI/Models/MapCamera/MapViewCamera.swift
+++ b/Sources/MapLibreSwiftUI/Models/MapCamera/MapViewCamera.swift
@@ -5,8 +5,7 @@ import MapLibre
 /// The SwiftUI MapViewCamera.
 ///
 /// This manages the camera state within the MapView.
-@MainActor
-public struct MapViewCamera: Hashable, Equatable, Sendable, @preconcurrency CustomStringConvertible {
+public struct MapViewCamera: Hashable, Equatable, Sendable, CustomStringConvertible {
     public enum Defaults {
         public static let coordinate = CLLocationCoordinate2D(latitude: 0, longitude: 0)
         public static let zoom: Double = 10


### PR DESCRIPTION
# Issue/Motivation

- Remove `@MainActor` from camera, this causes a lot of restriction on building camera structs outside of SwiftUI views.

## Tasklist

- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [ ] Add #fixes with the issue number that this PR addresses
- [ ] Update any documentation for affected APIs
