### PR TITLE
fixed: xcode version changed on gh action

### DIFF
--- a/.github/workflows/test-26.yml
+++ b/.github/workflows/test-26.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.1.0"
+          xcode-version: "26.1.1"
 
       - name: Checkout maplibre-swiftui-dsl-playground
         uses: actions/checkout@v4


### PR DESCRIPTION
# Issue/Motivation

- Fixes Xcode version (26.1.0 was replaced by 26.1.1).

## Tasklist

- [ ] Include tests (if applicable) and examples (new or edits)
- [ ] If there are any visual changes as a result, include before/after screenshots and/or videos
- [ ] Add #fixes with the issue number that this PR addresses
- [ ] Update any documentation for affected APIs
