### PR TITLE
Make mapContentInset environment value public

### DIFF
--- a/Sources/MapLibreSwiftUI/ViewModifiers/MapViewContentInset.swift
+++ b/Sources/MapLibreSwiftUI/ViewModifiers/MapViewContentInset.swift
@@ -12,7 +12,7 @@ import SwiftUI
 #endif
 
 @MainActor
-extension EnvironmentValues {
+public extension EnvironmentValues {
     var mapContentInset: UIEdgeInsets? {
         get { self[MapViewContentInsetKey.self] }
         set { self[MapViewContentInsetKey.self] = newValue }


### PR DESCRIPTION
# Issue/Motivation

Exposes the mapContentInset environment variable, so that Views such as the ones Ferrostar creates can read them in and apply them selectively. I'm creating a PR for Ferrostar which allows users to set the .mapContentInset on the Ferrostar view, so that the inset is applied when not navigating, while ferrostar applies its own when navigation is taking place. Example usage: https://github.com/stadiamaps/ferrostar/pull/872

Alternatively we could of course create a ferrostar specific override, but I think this solution is cleaner and could be a way of allowing people to control ferrostars non navigation behavior for other modifiers too if we like this pattern.


