### PR TITLE
fix(gestures): Reattached recognizers after MapView rebuilds

### DIFF
--- a/Sources/MapLibreSwiftUI/Extensions/Gestures/MapViewCoordinatorGestures.swift
+++ b/Sources/MapLibreSwiftUI/Extensions/Gestures/MapViewCoordinatorGestures.swift
@@ -12,6 +12,16 @@ extension MapViewCoordinator {
         addGestures(to: mapView, gestures: gestures)
     }
 
+    /// Restores gestures after a `.id(...)` rebuild, where the new coordinator
+    /// inherits an already-populated `MapViewGestureManager` and
+    /// `onGestureChange` never re-fires.
+    @MainActor func restoreGestures(on mapView: MLNMapView, gestures: [MapGesture]) {
+        if managedGestureRecognizers.count == gestures.count, !gestures.isEmpty {
+            return
+        }
+        syncGestures(on: mapView, gestures: gestures)
+    }
+
     /// Add an array of gestures to a map view.
     ///
     /// - Parameters:

--- a/Sources/MapLibreSwiftUI/MapView.swift
+++ b/Sources/MapLibreSwiftUI/MapView.swift
@@ -143,6 +143,10 @@ public struct MapView<T: MapViewHostViewController>: UIViewControllerRepresentab
         // FIXME: This should be a more selective update
         context.coordinator.updateStyleSource(styleSource, mapView: uiViewController.mapView)
         context.coordinator.updateLayers(mapView: uiViewController.mapView)
+        context.coordinator.restoreGestures(
+            on: uiViewController.mapView,
+            gestures: gestureManager.gestures
+        )
         context.coordinator.onMapIdle = onMapIdle
         context.coordinator.onMapDidFinishRendering = onMapDidFinishRendering
         context.coordinator.onMapTileError = onMapTileError

--- a/Tests/MapLibreSwiftUITests/Gestures/MapViewCoordinatorGestureRestoreTests.swift
+++ b/Tests/MapLibreSwiftUITests/Gestures/MapViewCoordinatorGestureRestoreTests.swift
@@ -1,0 +1,44 @@
+import MapLibre
+import XCTest
+@testable import MapLibreSwiftUI
+
+final class MapViewCoordinatorGestureRestoreTests: XCTestCase {
+    @MainActor
+    func testRestoreAttachesPrePopulatedGesturesAfterIdentityRebuild() throws {
+        // Simulate the `.id(...)` rebuild: the gesture modifier (and its
+        // manager) outlives the MapView, so by the time a new coordinator's
+        // `updateUIViewController` runs, the manager already holds gestures
+        // registered before the coordinator existed.
+        let mapView = try MapView(styleURL: XCTUnwrap(URL(string: "https://maplibre.org")))
+        let coordinator = mapView.makeCoordinator()
+        let mlnMapView = MLNMapView()
+        coordinator.mapView = mlnMapView
+
+        let tap = MapGesture(method: .tap(numberOfTaps: 1), onChange: .context { _ in })
+
+        XCTAssertEqual(coordinator.managedGestureRecognizers.count, 0)
+
+        coordinator.restoreGestures(on: mlnMapView, gestures: [tap])
+
+        XCTAssertEqual(coordinator.managedGestureRecognizers.count, 1)
+        XCTAssertTrue(coordinator.managedGestureRecognizers.first is UITapGestureRecognizer)
+    }
+
+    @MainActor
+    func testRestoreIsNoOpWhenAlreadyInSync() throws {
+        let mapView = try MapView(styleURL: XCTUnwrap(URL(string: "https://maplibre.org")))
+        let coordinator = mapView.makeCoordinator()
+        let mlnMapView = MLNMapView()
+        coordinator.mapView = mlnMapView
+
+        let tap = MapGesture(method: .tap(numberOfTaps: 1), onChange: .context { _ in })
+        coordinator.syncGestures(on: mlnMapView, gestures: [tap])
+        let attachedRecognizer = coordinator.managedGestureRecognizers.first
+
+        coordinator.restoreGestures(on: mlnMapView, gestures: [tap])
+
+        XCTAssertEqual(coordinator.managedGestureRecognizers.count, 1)
+        XCTAssertTrue(coordinator.managedGestureRecognizers.first === attachedRecognizer,
+                      "restore should not replace the recognizer when counts already match")
+    }
+}


### PR DESCRIPTION
# Issue/Motivation
SwiftUI `.id()` change recreates the coordinator and `MLNMapView` while the gesture modifier persists outside the identity boundary. The existing `onGestureChange` doesn't re-fire on rebuild, so the new `MLNMapView` ends up gesture-less.

# Solution
- Restored gestures in `updateUIViewController`.
- Added two unit tests.

## Tasklist

- [x] Include tests (if applicable) and examples (new or edits)
- [x] If there are any visual changes as a result, include before/after screenshots and/or videos
- [x] Add #fixes with the issue number that this PR addresses
- [x] Update any documentation for affected APIs
